### PR TITLE
Prefix & group changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
   - **--group-changes** (string):
     
     Groups changes based on group prefix found on each
-    unreleased change item. If no group prefix is found, change item will be 
+    unreleased change item. If no group prefix is found, the changed item will be 
     grouped under **Core**, as first group.
   
     Example:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
     ## 1.0.0 - 2018-10-22
     ### Core
     #### Changed
-    - This brokes something on root base repo
+    - change something on root level repo
 
     ### geut/cool-repo
     #### Added

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
     - [geut/cool-repo] New thing on geut/cool-repo group
 
     ### Changed
-    - This brokes something on root base repo
+    - This broke something on root base repo
 
     ### Fixed
     - [geut/cool-repo] Something on geut/cool-repo group

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
     ```bash
     $ chan fixed 'Something on geut/cool-repo group' -g geut/cool-repo
     $ chan added 'New thing on geut/cool-repo group' -g geut/cool-repo
-    $ chan changed 'This broke something on root base repo'
+    $ chan changed 'change something on root level repo'
     ```
 
     Now, your changelog should be:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
   
   - **--group-changes** (string):
     
-    Groups changes based on group prefix found on each
+    Group changes based on the `group prefix` found on each
     unreleased change item. If no group prefix is found, the changed item will be 
     grouped under **Core**, as first group.
   

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
     grouped under **Core**, as first group.
   
     Example:
-    Supose you make next changes on your changelog:
+    Suppose you make the next changes to your changelog:
     ```bash
     $ chan fixed 'Something on geut/cool-repo group' -g geut/cool-repo
     $ chan added 'New thing on geut/cool-repo group' -g geut/cool-repo

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
     ```bash
     $ chan fixed 'Something on geut/cool-repo group' -g geut/cool-repo
     $ chan added 'New thing on geut/cool-repo group' -g geut/cool-repo
-    $ chan changed 'This brokes something on root base repo'
+    $ chan changed 'This broke something on root base repo'
     ```
 
     Now, your changelog should be:

--- a/README.md
+++ b/README.md
@@ -58,28 +58,143 @@ In case you want to use an editor you can just omit the message parameter:
 $ chan added # this will open your $EDITOR
 ```
 
-#### available commands:
+#### Available commands:
 
-  - **init**               Creates a `CHANGELOG.md` if it does not exists. Chan will work with this file.
-     - **-o, --overwrite**  overwrite the current CHANGELOG.md [boolean]
-  - **added [msg]**       Writes your changelog indicating new stuff.
-  - **fixed [msg]**       Writes your changelog indicating fixed stuff.
-  - **changed [msg]**     Writes your changelog indicating updated stuff.
-  - **security [msg]**    Writes your changelog indicating security upgrades.
-  - **removed [msg]**     Writes your changelog indicating removed stuff.
-  - **deprecated [msg]**  Writes your changelog indicating deprecated stuff.
-  - **release \<semver\>**  Groups all your new features and marks a new release on your `CHANGELOG.md`.
-       - **--git-compare**  Overwrite the git compare by default [string]
+  - **init**                
+    Creates a `CHANGELOG.md` if it does not exists. Chan will work with this file.
+    
+  - **added [msg]**         
+    Writes your changelog indicating new stuff.
+    
+  - **fixed [msg]**         
+    Writes your changelog indicating fixed stuff.
+    
+  - **changed [msg]**       
+    Writes your changelog indicating updated stuff.
+    
+  - **security [msg]**      
+    Writes your changelog indicating security upgrades.
+    
+  - **removed [msg]**       
+    Writes your changelog indicating removed stuff.
+    
+  - **deprecated [msg]**    
+    Writes your changelog indicating deprecated stuff.
+    
+  - **release \<semver\>**  
+    Groups all your new features and marks a new release on your `CHANGELOG.md`.
+    
 
-#### options:
+#### Options
+Global options to `chan` command:
 
-  - **-p, --path**     Define the path of the CHANGELOG.md (cwd by default)   [string]
-  - **--stdout**       Define the output as STDOUT                           [boolean]
-  - **--silence**      Disable the console messages                          [boolean]
-  - **-u, --use**      Extend chan with your own commands        [array] [default: []]
-  - **--config**       Path to your JSON config file                          [string]
-  - **-h, --help**     Show help                                             [boolean]
-  - **-v, --version**  Show version number                                   [boolean]
+  - **-p, --path** (`string`)
+
+    Define the path of the CHANGELOG.md (cwd by default)
+  
+  - **--stdout** (`boolean`)
+
+    Define the output as STDOUT
+  
+  - **--silence** (`boolean`)
+  
+    Disable the console messages
+  
+  - **-u, --use** (`array`, default: `[]`)
+  
+    Extend chan with your own commands
+  
+  - **--config** (`string`)
+  
+    Path to your JSON config file
+  
+  - **-h, --help** (`boolean`)
+    
+    Show help
+  
+  - **-v, --version** (`boolean`)
+  
+    Show version number
+
+##### Init options
+
+  - **-o, --overwrite**  (`boolean`)
+
+    Overwrite the current CHANGELOG.md
+
+
+##### Change options
+Following options applies to `added`, `fixed`, `changed`, `security`, `removed` and `deprecated` commands:
+
+  - **-g, --group** (`string`)
+    
+    Prefix change with group provided
+    
+    Example:
+    ```bash
+    chan added --group=chan/sub-repo 'New stuff added'
+    ```
+    will add 
+    ```markdown
+    - [chan/sub-repo] New stuff added.
+    ```
+    to your changelog unreleased changes.
+
+
+##### Release options
+
+  - **--git-compare** (string)
+    
+    Overwrite the git compare by default
+  
+  - **--group-changes** (string):
+    
+    Groups changes based on group prefix found on each
+    unreleased change item. If no group prefix is found, change item will be 
+    grouped under **Core**, as first group.
+  
+    Example:
+    Supose you make next changes on your changelog:
+    ```bash
+    $ chan fixed 'Something on geut/cool-repo group' -g geut/cool-repo
+    $ chan added 'New thing on geut/cool-repo group' -g geut/cool-repo
+    $ chan changed 'This brokes something on root base repo'
+    ```
+
+    Now, your changelog should be:
+    ```markdown
+    ## [Unreleased]
+    ### Added
+    - [geut/cool-repo] New thing on geut/cool-repo group
+
+    ### Changed
+    - This brokes something on root base repo
+
+    ### Fixed
+    - [geut/cool-repo] Something on geut/cool-repo group
+    ```
+
+    Release time:
+    ```bash
+    chan release --group-changes 1.0.0
+    ```
+
+    Grouped changelog:
+    ```markdown
+    ## [Unreleased]
+
+    ## 1.0.0 - 2018-10-22
+    ### Core
+    #### Changed
+    - This brokes something on root base repo
+
+    ### geut/cool-repo
+    #### Added
+    - New thing on geut/cool-repo group
+
+    #### Fixed
+    - Something on geut/cool-repo group
+    ```
 
 > Notes:
 > - [_OPTIONAL_]

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
     - [geut/cool-repo] New thing on geut/cool-repo group
 
     ### Changed
-    - This broke something on root base repo
+    - change something on root level repo
 
     ### Fixed
     - [geut/cool-repo] Something on geut/cool-repo group

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Following options applies to `added`, `fixed`, `changed`, `security`, `removed` 
 
   - **-g, --group** (`string`)
     
-    Prefix change with group provided
+    Prefix change with provided group value
     
     Example:
     ```bash

--- a/src/api/change.js
+++ b/src/api/change.js
@@ -1,9 +1,9 @@
 import parser from '../parser';
 import writer from '../cli/lib/writer';
 
-const change = ({ type, msg, cwd, parserInstance = parser(cwd), write = writer({ parserInstance }) }) => {
+const change = ({ type, msg, cwd, parserInstance = parser(cwd), write = writer({ parserInstance }), group }) => {
     return parserInstance
-        .change(parserInstance.SEPARATORS[type], msg)
+        .change(parserInstance.SEPARATORS[type], msg, { group })
         .then(write);
 };
 

--- a/src/api/release.js
+++ b/src/api/release.js
@@ -1,8 +1,8 @@
 import parser from '../parser';
 import writer from '../cli/lib/writer';
 
-const release = ({ version, cwd, parserInstance = parser(cwd), write = writer({ parserInstance }) }) => {
-    return parserInstance.release(version)
+const release = ({ version, cwd, parserInstance = parser(cwd), write = writer({ parserInstance }), group = false }) => {
+    return parserInstance.release(version, { group })
         .then(write);
 };
 

--- a/src/cli/commands/changes.js
+++ b/src/cli/commands/changes.js
@@ -33,7 +33,7 @@ Object.keys(commands).forEach((type) => {
         builder(yargs) {
             return yargs.option('g', {
                 alias: 'group',
-                describe: 'Prefix change with [<group>]. This allow to group changes on release.',
+                describe: 'Prefix change with [<group>]. This allows to group changes on release time.',
                 type: 'string'
             });
         },

--- a/src/cli/commands/changes.js
+++ b/src/cli/commands/changes.js
@@ -46,7 +46,7 @@ Object.keys(commands).forEach((type) => {
             if (argv.msg) {
                 result = Promise.resolve(argv.msg);
             } else {
-                result = this.openInEditor();
+                result = this.openInEditor({ group: argv.group });
             }
 
             return result

--- a/src/cli/commands/changes.js
+++ b/src/cli/commands/changes.js
@@ -54,7 +54,7 @@ Object.keys(commands).forEach((type) => {
                     if (!msg || msg.length === 0) {
                         return null;
                     }
-                    
+
                     return change({ type, msg, parserInstance, write, group: argv.group });
                 })
                 .catch((e) => {

--- a/src/cli/commands/changes.js
+++ b/src/cli/commands/changes.js
@@ -30,8 +30,15 @@ const commands = {
 
 Object.keys(commands).forEach((type) => {
     const command = Object.assign({}, commands[type], {
-        handler(parser, argv, write) {
-            if ( !parser.exists() ) {
+        builder(yargs) {
+            return yargs.option('g', {
+                alias: 'group',
+                describe: 'Prefix change with [<group>]. This allow to group changes on release.',
+                type: 'string'
+            });
+        },
+        handler(parserInstance, argv, write) {
+            if ( !parserInstance.exists() ) {
                 throw new Error('CHANGELOG.md does not exists. You can run: chan init in order to create a fresh new one.');
             }
 
@@ -47,7 +54,8 @@ Object.keys(commands).forEach((type) => {
                     if (!msg || msg.length === 0) {
                         return null;
                     }
-                    return change({ type, msg, parserInstance:parser, write });
+                    
+                    return change({ type, msg, parserInstance, write, group: argv.group });
                 })
                 .catch((e) => {
                     this.log().error(e.message);

--- a/src/cli/commands/release.js
+++ b/src/cli/commands/release.js
@@ -11,7 +11,7 @@ export default function () {
             });
 
             yargs.option('group-changes', {
-                describe: 'Group changes based on [<group>] prefix on each change.',
+                describe: 'Group changes based on [<group>] prefix.',
                 type: 'boolean'
             });
 

--- a/src/cli/commands/release.js
+++ b/src/cli/commands/release.js
@@ -5,10 +5,17 @@ export default function () {
         command: 'release <semver>',
         describe: 'Groups all your new features and marks a new release on your CHANGELOG.md.',
         builder(yargs) {
-            return yargs.option('git-compare', {
+            yargs.option('git-compare', {
                 describe: 'Overwrite the git url compare by default.\n e.g.: https://bitbucket.org/project/compare/<from>..<to>',
                 type: 'string'
             });
+
+            yargs.option('group-changes', {
+                describe: 'Group changes based on [<group>] prefix on each change.',
+                type: 'boolean'
+            })
+
+            return yargs;
         },
         handler(parser, argv, write) {
             if ( !parser.exists() ) {
@@ -23,7 +30,7 @@ export default function () {
                 return null;
             }
 
-            return release({ version, parserInstance: parser, write })
+            return release({ version, parserInstance: parser, write, group: argv.groupChanges })
                 .then(() => {
                     this.log().success(`Version ${version} released :)`);
                 })

--- a/src/cli/commands/release.js
+++ b/src/cli/commands/release.js
@@ -13,7 +13,7 @@ export default function () {
             yargs.option('group-changes', {
                 describe: 'Group changes based on [<group>] prefix on each change.',
                 type: 'boolean'
-            })
+            });
 
             return yargs;
         },

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -32,8 +32,8 @@ const cli = {
         }
         return _log;
     },
-    openInEditor() {
-        return openInEditor();
+    openInEditor(options) {
+        return openInEditor(options);
     },
     commands() {
         return _commands;

--- a/src/cli/lib/open-in-editor.js
+++ b/src/cli/lib/open-in-editor.js
@@ -5,16 +5,20 @@ const tmpFile = tempfile('.md');
 const readFile = pify(require('fs').readFile);
 const editor = pify(require('editor'));
 
-export default function openInEditor(silence = true) {
+export default function openInEditor({ group = null, silence = true }) {
     return editor(tmpFile)
         .then(() => {
-
             return readFile(tmpFile, 'utf8');
         })
         .then((data) => {
             if (data.length === 0) {
                 throw new Error(`The file is empty '${tmpFile}'`);
             }
+
+            if (group) {
+                return `[${group}] ${data}`;
+            }
+
             return data;
         })
         .catch((e) => {

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -51,11 +51,11 @@ export default function parser(dir = process.cwd()) {
             _mtree = mtree(this);
             return _mtree;
         },
-        change(type, value) {
-            return this.getMTREE().insert(type, value);
+        change(type, value, options) {
+            return this.getMTREE().insert(type, value, options);
         },
-        release(version, gitCompare = null) {
-            return this.getMTREE().version(version, gitCompare);
+        release(version, options) {
+            return this.getMTREE().version(version, options);
         },
         findRelease(version) {
             return this.getMTREE().findRelease(version);

--- a/src/parser/mtree/index.js
+++ b/src/parser/mtree/index.js
@@ -20,6 +20,7 @@ const TPL = {
     H4: '#### <text>',
     VERSION: '## [<version>] - <date>',
     LI: '- <text>',
+    LI1: '  - <text>',
     DEFINITION: '[<version>]: <git-compare>'
 };
 
@@ -128,30 +129,29 @@ function groupChanges(changes = []) {
 
     for (const { text: type, children } of changes) {
         for (const { text, group = '' } of children) {
-            if (!groups[group]) groups[group] = {};
-            if (!groups[group][type]) groups[group][type] = [];
+            if (!groups[type]) groups[type] = {};
+            if (!groups[type][group]) groups[type][group] = [];
 
-            groups[group][type].push(textFromLI({ text }));
+            groups[type][group].push(textFromLI({ text }));
         }
     }
 
-    const tpl = Object.keys(groups).sort().reduce((result, group) => {
-        result += TPL.H3.replace('<text>', group || 'Core') + LINE; // ### group OR ### Core
+    const tpl = Object.keys(groups).map(type => {
+        let result = TPL.H3.replace('<text>', type) + LINE; // #### Added
 
-        result += Object.keys(groups[group]).map(type => {
-            let typeTpl = TPL.H4.replace('<text>', type) + LINE; // #### Added
+        result += Object.keys(groups[type]).sort().map(group => {
+            let typeTpl = TPL.LI.replace('<text>', group || 'Core') + LINE; // ### group OR ### Core
 
-            typeTpl += groups[group][type].reduce((resultItems, text) => {
-                return resultItems + TPL.LI.replace('<text>', text);
-            }, '');
+            typeTpl += groups[type][group].map(text => {
+                return TPL.LI1.replace('<text>', text);
+            }).join(LINE);
 
             return typeTpl;
-        }).join(BREAK);
-
-        result += BREAK;
+        }).join(LINE);
 
         return result;
-    }, '');
+
+    }).join(BREAK);
 
     return tpl;
 }

--- a/src/parser/mtree/index.js
+++ b/src/parser/mtree/index.js
@@ -126,7 +126,7 @@ function groupFromLI(li) {
 function groupChanges(changes = []) {
     const groups = {};
 
-    for (const {text: type, children} of changes) {
+    for (const { text: type, children } of changes) {
         for (const { text, group = '' } of children) {
             if (!groups[group]) groups[group] = {};
             if (!groups[group][type]) groups[group][type] = [];
@@ -141,8 +141,8 @@ function groupChanges(changes = []) {
         result += Object.keys(groups[group]).map(type => {
             let typeTpl = TPL.H4.replace('<text>', type) + LINE; // #### Added
 
-            typeTpl += groups[group][type].reduce((result, text) => {
-                return result + TPL.LI.replace('<text>', text);
+            typeTpl += groups[group][type].reduce((resultItems, text) => {
+                return resultItems + TPL.LI.replace('<text>', text);
             }, '');
 
             return typeTpl;

--- a/src/parser/mtree/index.js
+++ b/src/parser/mtree/index.js
@@ -17,12 +17,14 @@ const BREAK = LINE + LINE;
 const TPL = {
     UNRELEASED: '## [Unreleased]',
     H3: '### <text>',
+    H4: '#### <text>',
     VERSION: '## [<version>] - <date>',
     LI: '- <text>',
     DEFINITION: '[<version>]: <git-compare>'
 };
 
 const REGEX_GET_VERSION = /##\s\[?([0-9\.]*)\]?\s-/g;
+const REGEX_GROUP = /\[([^\]]+)\]\s/g;
 
 function processRelease(release, node, elem, stringify, m) {
     if (elem.type === 'heading') {
@@ -34,9 +36,15 @@ function processRelease(release, node, elem, stringify, m) {
         const mLI = m('- ');
         for (let li of elem.children) {
             mLI.children[0] = li;
+
+            const text = stringify(mLI).slice(2);
+            const group = REGEX_GROUP.exec(text);
+
             node.children.push({
-                text: stringify(mLI).slice(2)
+                text: text.replace(REGEX_GROUP, ''),
+                group: group ? group[1] : undefined
             });
+
         }
 
     }
@@ -99,23 +107,72 @@ function decode(parser) {
     return that;
 }
 
-function compileRelease(release = 0, children, m, version = null) {
-    let tpl = this.releases[release].children.map((node) => {
-        return TPL.H3.replace('<text>', node.text) + LINE + node.children.reduce((result, li) => {
-            return result +
-                LINE +
-                TPL.LI.replace(
-                    '<text>',
-                    li.text.split('\n').map((line, i) => {
-                        line = line.trim();
-                        if (line.length > 0 && i > 0) {
-                            return '  ' + line;
-                        }
-                        return line;
-                    }).join('\n')
-                );
-        }, '');
-    }).join(BREAK);
+function textFromLI(li) {
+    return li.text.split('\n').map((line, i) => {
+        line = line.trim();
+        if (line.length > 0 && i > 0) {
+            return '  ' + line;
+        }
+        return line;
+    }).join('\n');
+}
+
+function groupFromLI(li) {
+    if (!li.group) return '';
+
+    return `[${li.group}] `;
+}
+
+function groupChanges(changes = []) {
+    const groups = {};
+
+    for (const {text: type, children} of changes) {
+        for (const { text, group = '' } of children) {
+            if (!groups[group]) groups[group] = {};
+            if (!groups[group][type]) groups[group][type] = [];
+
+            groups[group][type].push(textFromLI({ text }));
+        }
+    }
+
+    const tpl = Object.keys(groups).sort().reduce((result, group) => {
+        result += TPL.H3.replace('<text>', group || 'Core') + LINE; // ### group OR ### Core
+
+        result += Object.keys(groups[group]).map(type => {
+            let typeTpl = TPL.H4.replace('<text>', type) + LINE; // #### Added
+
+            typeTpl += groups[group][type].reduce((result, text) => {
+                return result + TPL.LI.replace('<text>', text);
+            }, '');
+
+            return typeTpl;
+        }).join(BREAK);
+
+        result += BREAK;
+
+        return result;
+    }, '');
+
+    return tpl;
+}
+
+function compileRelease(release = 0, children, m, version = null, group = false) {
+    let tpl;
+
+    if (group) {
+        tpl = groupChanges(this.releases[release].children);
+    } else {
+        tpl = this.releases[release].children.map((node) => {
+            return TPL.H3.replace('<text>', node.text) + LINE + node.children.reduce((result, li) => {
+                return result +
+                    LINE +
+                    TPL.LI.replace(
+                        '<text>',
+                        groupFromLI(li) + textFromLI(li)
+                    );
+            }, '');
+        }).join(BREAK);
+    }
 
     if (version) {
         let tplVersion = TPL.VERSION
@@ -226,17 +283,17 @@ export default function mtree(parser) {
         return that.compileRelease(0);
     };
 
-    that.version = function (version) {
-        compileRelease.call(this, 0, parser.root.children, parser.createMDAST, version);
+    that.version = function (version, options) {
+        compileRelease.call(this, 0, parser.root.children, parser.createMDAST, version, options.group);
 
         return that.addDefinition(version, gitCompare);
     };
 
-    that.insert = function (type, value) {
+    that.insert = function (type, value, options) {
         const node = findHeaderOrCreate.call(this, type);
-        node.children.push({
-            text: value
-        });
+
+        node.children.push({ text: value, group: options.group });
+
         that.compileUnreleased();
         return Promise.resolve();
     };

--- a/src/parser/mtree/index.js
+++ b/src/parser/mtree/index.js
@@ -140,10 +140,12 @@ function groupChanges(changes = []) {
         let result = TPL.H3.replace('<text>', type) + LINE; // #### Added
 
         result += Object.keys(groups[type]).sort().map(group => {
-            let typeTpl = TPL.LI.replace('<text>', group || 'Core') + LINE; // ### group OR ### Core
+            const haveGroup = !!group;
+
+            let typeTpl = haveGroup ? (TPL.LI.replace('<text>', group) + LINE) : ''; // ### group OR ### Core
 
             typeTpl += groups[type][group].map(text => {
-                return TPL.LI1.replace('<text>', text);
+                return (haveGroup ? TPL.LI1 : TPL.LI).replace('<text>', text);
             }).join(LINE);
 
             return typeTpl;

--- a/src/parser/mtree/index.js
+++ b/src/parser/mtree/index.js
@@ -142,7 +142,7 @@ function groupChanges(changes = []) {
         result += Object.keys(groups[type]).sort().map(group => {
             const haveGroup = !!group;
 
-            let typeTpl = haveGroup ? (TPL.LI.replace('<text>', group) + LINE) : ''; // ### group OR ### Core
+            let typeTpl = haveGroup ? TPL.LI.replace('<text>', group) + LINE : ''; // ### group OR ### Core
 
             typeTpl += groups[type][group].map(text => {
                 return (haveGroup ? TPL.LI1 : TPL.LI).replace('<text>', text);

--- a/test/commands/changes.js
+++ b/test/commands/changes.js
@@ -55,3 +55,54 @@ test('test 2 commands in a row => CHANGELOG.md already exists and contains chang
             t.deepEqual(result, expected, 'chan injected the new changes labeled as added and fixed successfully.');
         });
 });
+
+test('test --group option => Add new changes to the same group', t => {
+    const groupedChanges = cli(tmp, [
+        { name: 'added', args: { msg: 'added 1', group: 'group-1' } },
+        { name: 'changed', args: { msg: 'changed 1', group: 'group-1' } }
+    ], 'grouped/empty');
+
+    return Promise.all([
+        groupedChanges,
+        readChangelog('expected/grouped/same-group')
+    ]).then(values => {
+        const [result, expected] = values;
+        t.deepEqual(result, expected, 'chan injected the new grouped changes successfully.');
+    });
+}); 
+
+test('test --group option => Add new changes to different groups', t => {
+    const groupedChanges = cli(tmp, [
+        { name: 'added', args: { msg: 'added 1', group: 'group-1' } },
+        { name: 'changed', args: { msg: 'changed 2', group: 'group-2' } },
+        { name: 'changed', args: { msg: 'changed 1', group: 'group-1' } },
+        { name: 'added', args: { msg: 'added 2', group: 'group-2' } },
+        { name: 'fixed', args: { msg: 'fixed 1', group: 'group-3' } }
+    ], 'grouped/empty');
+
+    return Promise.all([
+        groupedChanges,
+        readChangelog('expected/grouped/different-group')
+    ]).then(values => {
+        const [result, expected] = values;
+        t.deepEqual(result, expected, 'chan injected the new grouped changes successfully.');
+    });
+});
+
+test('test --group option => Add new changes with/without group', t => {
+    const groupedChanges = cli(tmp, [
+        { name: 'added', args: { msg: 'added 1', group: 'group-1' } },
+        { name: 'changed', args: { msg: 'changed 2', group: 'group-2' } },
+        { name: 'changed', args: { msg: 'changed 1', group: 'group-1' } },
+        { name: 'added', args: { msg: 'added 2 to core' } },
+        { name: 'fixed', args: { msg: 'fixed 1 to core' } }
+    ], 'grouped/empty');
+
+    return Promise.all([
+        groupedChanges,
+        readChangelog('expected/grouped/mixed-group-no-group')
+    ]).then(values => {
+        const [result, expected] = values;
+        t.deepEqual(result, expected, 'chan injected the new grouped changes successfully.');
+    });
+});

--- a/test/commands/expected/grouped/different-group/CHANGELOG.md
+++ b/test/commands/expected/grouped/different-group/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [group-1] added 1
+- [group-2] added 2
+
+### Changed
+- [group-2] changed 2
+- [group-1] changed 1
+
+### Fixed
+- [group-3] fixed 1

--- a/test/commands/expected/grouped/mixed-group-no-group/CHANGELOG.md
+++ b/test/commands/expected/grouped/mixed-group-no-group/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [group-1] added 1
+- added 2 to core
+
+### Changed
+- [group-2] changed 2
+- [group-1] changed 1
+
+### Fixed
+- fixed 1 to core

--- a/test/commands/expected/grouped/released-no-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-no-core/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 1.0.0 - 2018-10-22
+### group-1
+#### Added
+- added 1
+
+#### Changed
+- changed 1
+
+### group-2
+#### Changed
+- changed 2
+
+[unreleased]: https://github.com/geut/chan/compare/v1.0.0...HEAD

--- a/test/commands/expected/grouped/released-no-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-no-core/CHANGELOG.md
@@ -7,15 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## 1.0.0 - <currentDate>
-### group-1
-#### Added
-- added 1
+### Added
+- group-1
+  - added 1
 
-#### Changed
-- changed 1
-
-### group-2
-#### Changed
-- changed 2
+### Changed
+- group-1
+  - changed 1
+- group-2
+  - changed 2
 
 [unreleased]: https://github.com/geut/chan/compare/v1.0.0...HEAD

--- a/test/commands/expected/grouped/released-no-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-no-core/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## 1.0.0 - 2018-10-22
+## 1.0.0 - <currentDate>
 ### group-1
 #### Added
 - added 1

--- a/test/commands/expected/grouped/released-with-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-with-core/CHANGELOG.md
@@ -7,22 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## 1.0.0 - <currentDate>
-### Core
-#### Deprecated
-- deprecated 1
+### Added
+- group-1
+  - added 1
 
-#### Fixed
-- fixed 1
+### Changed
+- group-1
+  - changed 1
+- group-2
+  - changed 2
 
-### group-1
-#### Added
-- added 1
+### Deprecated
+- Core
+  - deprecated 1
 
-#### Changed
-- changed 1
-
-### group-2
-#### Changed
-- changed 2
+### Fixed
+- Core
+  - fixed 1
 
 [unreleased]: https://github.com/geut/chan/compare/v1.0.0...HEAD

--- a/test/commands/expected/grouped/released-with-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-with-core/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 1.0.0 - 2018-10-22
+### Core
+#### Deprecated
+- deprecated 1
+
+#### Fixed
+- fixed 1
+
+### group-1
+#### Added
+- added 1
+
+#### Changed
+- changed 1
+
+### group-2
+#### Changed
+- changed 2
+
+[unreleased]: https://github.com/geut/chan/compare/v1.0.0...HEAD

--- a/test/commands/expected/grouped/released-with-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-with-core/CHANGELOG.md
@@ -18,11 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - changed 2
 
 ### Deprecated
-- Core
-  - deprecated 1
+- deprecated 1
 
 ### Fixed
-- Core
-  - fixed 1
+- fixed 1
 
 [unreleased]: https://github.com/geut/chan/compare/v1.0.0...HEAD

--- a/test/commands/expected/grouped/released-with-core/CHANGELOG.md
+++ b/test/commands/expected/grouped/released-with-core/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## 1.0.0 - 2018-10-22
+## 1.0.0 - <currentDate>
 ### Core
 #### Deprecated
 - deprecated 1

--- a/test/commands/expected/grouped/same-group/CHANGELOG.md
+++ b/test/commands/expected/grouped/same-group/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [group-1] added 1
+
+### Changed
+- [group-1] changed 1

--- a/test/commands/fixtures/grouped/empty/CHANGELOG.md
+++ b/test/commands/fixtures/grouped/empty/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/test/commands/fixtures/grouped/unreleased_no_core/CHANGELOG.md
+++ b/test/commands/fixtures/grouped/unreleased_no_core/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [group-1] added 1
+
+### Changed
+- [group-2] changed 2
+- [group-1] changed 1

--- a/test/commands/fixtures/grouped/unreleased_with_core/CHANGELOG.md
+++ b/test/commands/fixtures/grouped/unreleased_with_core/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [group-1] added 1
+
+### Changed
+- [group-2] changed 2
+- [group-1] changed 1
+
+### Deprecated
+- deprecated 1
+
+### Fixed
+- fixed 1

--- a/test/commands/helpers/stubs/git-url-compare.js
+++ b/test/commands/helpers/stubs/git-url-compare.js
@@ -7,7 +7,7 @@ export default {
                 return resolve(gitCompare);
             }
 
-            return resolve(defineGITCompare('git@github.com:geut/chan.git'));
+            return resolve(defineGITCompare('git@github.com/geut/chan.git'));
         });
     },
     defineGITCompare

--- a/test/commands/release.js
+++ b/test/commands/release.js
@@ -41,3 +41,27 @@ test('CHANGELOG.md exists and contains new changes along with previous versions.
             t.deepEqual(result, expected, 'chan release adds a new version section to the CHANGELOG.md on top of previous versions.');
         });
 });
+
+test('test --group-changes option => Groups changes by prefix (no core changes)', t => {
+    return Promise.all([
+        cli(tmp, { name: 'release', args: { semver: '1.0.0', groupChanges: true } }, '../grouped/unreleased_no_core'), 
+        readChangelog('expected/grouped/released-no-core')
+    ])
+        .then((values) => {
+            let [result, expected] = values;
+            expected = expected.replace('<currentDate>', now());
+            t.deepEqual(result, expected, 'chan release adds a new version section grouped by prefixes detected (no core changes).');
+        });
+}); 
+
+test('test --group-changes option => Groups changes by prefix (with core changes)', t => {
+    return Promise.all([
+        cli(tmp, { name: 'release', args: { semver: '1.0.0', groupChanges: true } }, '../grouped/unreleased_with_core'), 
+        readChangelog('expected/grouped/released-with-core')
+    ])
+        .then((values) => {
+            let [result, expected] = values;
+            expected = expected.replace('<currentDate>', now());
+            t.deepEqual(result, expected, 'chan release adds a new version section grouped by prefixes detected (with core changes)');
+        });
+}); 

--- a/test/commands/release.js
+++ b/test/commands/release.js
@@ -44,7 +44,7 @@ test('CHANGELOG.md exists and contains new changes along with previous versions.
 
 test('test --group-changes option => Groups changes by prefix (no core changes)', t => {
     return Promise.all([
-        cli(tmp, { name: 'release', args: { semver: '1.0.0', groupChanges: true } }, '../grouped/unreleased_no_core'), 
+        cli(tmp, { name: 'release', args: { semver: '1.0.0', groupChanges: true } }, '../grouped/unreleased_no_core'),
         readChangelog('expected/grouped/released-no-core')
     ])
         .then((values) => {
@@ -52,11 +52,11 @@ test('test --group-changes option => Groups changes by prefix (no core changes)'
             expected = expected.replace('<currentDate>', now());
             t.deepEqual(result, expected, 'chan release adds a new version section grouped by prefixes detected (no core changes).');
         });
-}); 
+});
 
 test('test --group-changes option => Groups changes by prefix (with core changes)', t => {
     return Promise.all([
-        cli(tmp, { name: 'release', args: { semver: '1.0.0', groupChanges: true } }, '../grouped/unreleased_with_core'), 
+        cli(tmp, { name: 'release', args: { semver: '1.0.0', groupChanges: true } }, '../grouped/unreleased_with_core'),
         readChangelog('expected/grouped/released-with-core')
     ])
         .then((values) => {
@@ -64,4 +64,4 @@ test('test --group-changes option => Groups changes by prefix (with core changes
             expected = expected.replace('<currentDate>', now());
             t.deepEqual(result, expected, 'chan release adds a new version section grouped by prefixes detected (with core changes)');
         });
-}); 
+});


### PR DESCRIPTION
This PR:
1. Adds a new option **`--group=<group_name>, -g <group_name>`** on `change` commands, for:
    - Visual prefixing changes. Something like:
    ```
    - [geut/chan] Added new options to api.
    ```
    - Parse/add `group` property on every change item, at `CHANGELOG.md` read time.

    Use it as: 
    ```bash
    chan added --group=chan/sub-repo 'New stuff added'
    ```
2. Adds a new option **`--group-changes`** on `release` command, that groups changes based on group prefix found on each unreleased change item. If no group prefix is found, change item will be grouped under `Core`, as first group.

Example:
Supose you make next changes on your changelog:
```bash
$ chan fixed 'Something on geut/cool-repo group' -g geut/cool-repo
$ chan added 'New thing on geut/cool-repo group' -g geut/cool-repo
$ chan changed 'This brokes something on root base repo'
```

Now, your changelog should be:
```markdown
## [Unreleased]
### Added
- [geut/cool-repo] New thing on geut/cool-repo group

### Changed
- This brokes something on root base repo

### Fixed
- [geut/cool-repo] Something on geut/cool-repo group
```

Release time:
```bash
chan release --group-changes 1.0.0
```

Grouped changelog:
```markdown
## [Unreleased]

## 1.0.0 - 2018-10-17
### Core
#### Changed
- This brokes something on root base repo

### geut/cool-repo
#### Added
- New thing on geut/cool-repo group

#### Fixed
- Something on geut/cool-repo group
```

Both options are useful for monorepo changelogs where you might want to group/separate modifications by packages.