### PR TITLE
Remove main field from package.json

### DIFF
--- a/jest-module-resolver.js
+++ b/jest-module-resolver.js
@@ -1,0 +1,13 @@
+// temporary workaround while we wait for https://github.com/facebook/jest/issues/9771
+const resolver = require('enhanced-resolve').create.sync({
+  conditionNames: ['require', 'node', 'default', 'import'],
+  extensions: ['.js', '.json', '.node', '.ts']
+})
+
+
+module.exports = function (request, options) {
+  if (['fs', 'url', 'path', 'assert'].includes(request)) {
+    return options.defaultResolver(request, options);
+  }
+  return resolver(options.basedir, request)
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "lerna run lint -- -- --fix"
   },
   "devDependencies": {
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "enhanced-resolve": "^5.8.2"
   },
   "keywords": [
     "cli",

--- a/packages/chan-core/package.json
+++ b/packages/chan-core/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "API and transformers to work with chast",
   "type": "module",
-  "main": "./src/index.js",
+  "module": "./src/index.js",
   "exports": {
     ".": "./src/index.js"
   },
@@ -31,6 +31,7 @@
     "vfile-reporter": "^7.0.0"
   },
   "jest": {
+    "resolver": "<rootDir>/../../jest-module-resolver.js",
     "transform": {},
     "setupFiles": [
       "jest-date-mock"

--- a/packages/chan-stringify/package.json
+++ b/packages/chan-stringify/package.json
@@ -4,7 +4,7 @@
   "description": "Stringify chast to keepachangelog markdown",
   "homepage": "http://geutstudio.com",
   "type": "module",
-  "main": "./src/index.js",
+  "module": "./src/index.js",
   "exports": {
     ".": "./src/index.js"
   },
@@ -31,6 +31,7 @@
     "vfile-reporter": "^7.0.0"
   },
   "jest": {
+    "resolver": "<rootDir>/../../jest-module-resolver.js",
     "transform": {}
   },
   "standard": {

--- a/packages/chast/package.json
+++ b/packages/chast/package.json
@@ -4,7 +4,7 @@
   "description": "Unist compatible spec for changelogs and helpers to nodes creation",
   "homepage": "http://geutstudio.com",
   "type": "module",
-  "main": "./src/index.js",
+  "module": "./src/index.js",
   "exports": {
     ".": "./src/index.js",
     "./actions": "./src/actions.js"

--- a/packages/git-url-parse/package.json
+++ b/packages/git-url-parse/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "Function to parse a git url and generates template url for the git compare preview.",
   "type": "module",
-  "main": "./src/index.js",
+  "module": "./src/index.js",
   "exports": {
     ".": "./src/index.js"
   },

--- a/packages/remark-chan/package.json
+++ b/packages/remark-chan/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "Parser mdast to chast",
   "type": "module",
-  "main": "./src/index.js",
+  "module": "./src/index.js",
   "exports": {
     ".": "./src/index.js"
   },
@@ -29,6 +29,7 @@
     "unist-util-inspect": "^7.0.0"
   },
   "jest": {
+    "resolver": "<rootDir>/../../jest-module-resolver.js",
     "transform": {}
   },
   "standard": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2700,6 +2700,14 @@ encoding@^0.1.12:
   dependencies:
     iconv-lite "^0.6.2"
 
+enhanced-resolve@^5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -6847,6 +6855,11 @@ table@^5.2.3:
     lodash "^4.17.14"
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
+
+tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
 tar@^4.4.12:
   version "4.4.13"


### PR DESCRIPTION
ESM modules does not require a `main` field in `package.json`. The main field was used as a workaround for jest not being able to resolve exports nor module fields.

This PR adds a custom module resolver thru `enhanced-resolve` till the jest issue is fixed.