### PR TITLE
Add new config `--release-prefix` for addRelease and createGithubRelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new config `--release-prefix` for addRelease and createGithubRelease
 
 ## [3.1.0] - 2021-07-07
 ### Added

--- a/packages/chan-core/README.md
+++ b/packages/chan-core/README.md
@@ -43,7 +43,8 @@ await addRelease(file,   {
   version: '0.0.2',
   gitTemplate: 'https://github.com/geut/chan/compare/[prev]...[next]',
   gitBranch: 'HEAD',
-  mergePrerelease: true
+  mergePrerelease: true,
+  releasePrefix: 'v'
 })
 
 await getMarkdownRelease(file, { version: '0.0.1' })
@@ -61,7 +62,7 @@ true to overwrite if file already exists. Default to `false`
 #### `changes` {Array}
 chast representation for a set of changes.
 
-### `addRelease (from, { version, date, yanked, gitTemplate, gitBranch, allowYanked, allowPrerelease, mergePrerelease })`
+### `addRelease (from, { version, date, yanked, gitTemplate, gitBranch, allowYanked, allowPrerelease, mergePrerelease, releasePrefix })`
 #### `from` {vfile}
 
 ### `getMarkdownRelease (from, { version })`

--- a/packages/chan-core/src/transformer.js
+++ b/packages/chan-core/src/transformer.js
@@ -71,7 +71,8 @@ export function addRelease ({
   gitBranch,
   allowYanked,
   allowPrerelease,
-  mergePrerelease
+  mergePrerelease,
+  releasePrefix = 'v'
 }) {
   function compile (tree, file) {
     const preface = select('preface', tree)
@@ -136,14 +137,14 @@ export function addRelease ({
       const lastRelease = releases[0]
 
       if (lastRelease) {
-        releaseUrl = gitCompareTemplate.replace('[prev]', `v${lastRelease.version}`).replace('[next]', `v${version}`)
+        releaseUrl = gitCompareTemplate.replace('[prev]', `${releasePrefix}${lastRelease.version}`).replace('[next]', `${releasePrefix}${version}`)
       } else {
         // first release, the url should point to the tag instead of a compare url
-        releaseUrl = gitReleaseTemplate.replace('[next]', `v${version}`)
+        releaseUrl = gitReleaseTemplate.replace('[next]', `${releasePrefix}${version}`)
       }
 
       // in the future the template v[version] could be defined by the user, maybe?
-      unreleased.url = gitCompareTemplate.replace('[prev]', `v${version}`).replace('[next]', gitBranch)
+      unreleased.url = gitCompareTemplate.replace('[prev]', `${releasePrefix}${version}`).replace('[next]', gitBranch)
     }
 
     const newRelease = createRelease(

--- a/packages/chan-core/tests/__snapshots__/release.test.js.snap
+++ b/packages/chan-core/tests/__snapshots__/release.test.js.snap
@@ -107,6 +107,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 "
 `;
 
+exports[`add release with altered prefix 1`] = `
+"# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2019-01-11
+### Changed
+- Changed X by Y.
+
+[Unreleased]: https://github.com/geut/chan/compare/0.0.1...HEAD
+[0.0.1]: https://github.com/geut/chan/releases/tag/0.0.1
+"
+`;
+
 exports[`add release with url 1`] = `
 "# Changelog
 All notable changes to this project will be documented in this file.

--- a/packages/chan-core/tests/release.test.js
+++ b/packages/chan-core/tests/release.test.js
@@ -77,3 +77,15 @@ test('add release merged with prereleases', async () => {
 
   expect(file.toString()).toMatchSnapshot()
 })
+
+test('add release with altered prefix', async () => {
+  const file = await addRelease(toVFile.readSync(`${dirname(import.meta)}/__files__/unreleased.md`), {
+    version: '0.0.1',
+    gitReleaseTemplate: 'https://github.com/geut/chan/releases/tag/[next]',
+    gitCompareTemplate: 'https://github.com/geut/chan/compare/[prev]...[next]',
+    gitBranch: 'HEAD',
+    releasePrefix: ''
+  })
+
+  expect(file.toString()).toMatchSnapshot()
+})

--- a/packages/chan/README.md
+++ b/packages/chan/README.md
@@ -182,6 +182,17 @@ Example:
 will generate releases with the url:
 `https://github.com/geut/chan/compare/v0.0.1..master`
 
+#### `--release-prefix` (`string`)
+
+You can provide a custom release prefix fitting your project release process.  (`v` by default).
+
+Example:
+`V`
+will generate releases with the url:
+`https://github.com/geut/chan/compare/V0.0.1..HEAD`
+
+> Also, this kind of configurations can be defined in the [package.json](#config-package-json).
+
 #### `--allow-yanked` (`boolean`)
 
 Allow yanked releases. When this option is true and the release doesn't have new changes it will released as a yanked version.
@@ -211,6 +222,17 @@ Creates a github release.
 #### `--git-url` (`string`)
 
 Define the url of the repository project.
+
+#### `--release-prefix` (`string`)
+
+You can provide a custom release prefix fitting your project release process.  (`v` by default).
+
+Example:
+`V`
+will generate releases with the url:
+`https://github.com/geut/chan/compare/V0.0.1..HEAD`
+
+> Also, this kind of configurations can be defined in the [package.json](#config-package-json).
 
 ## <a name="command-show"></a>`chan show <semver>`
 
@@ -242,7 +264,8 @@ You can configure the chan options using the `package.json` or a rc file (`.chan
 
 ```json
 {
-  "git-url": "https://github.com/geut/chan"
+  "git-url": "https://github.com/geut/chan",
+  "release-prefix": "v"
 }
 ```
 
@@ -251,7 +274,8 @@ package.json
 ```json
 {
   "chan": {
-    "git-url": "https://github.com/geut/chan"
+    "git-url": "https://github.com/geut/chan",
+    "release-prefix": "v"
   }
 }
 ```

--- a/packages/chan/src/commands/gh-release.js
+++ b/packages/chan/src/commands/gh-release.js
@@ -28,10 +28,15 @@ export const builder = {
   'git-url': {
     describe: 'Define the url of the repository project.',
     type: 'string'
+  },
+  'release-prefix': {
+    describe: 'Define the release prefix to be used.',
+    type: 'string',
+    default: 'v'
   }
 }
 
-export async function handler ({ semver: userVersion, path, gitUrl, verbose, stdout }) {
+export async function handler ({ semver: userVersion, path, gitUrl, releasePrefix, verbose, stdout }) {
   const { success, info, warn, error } = createLogger({ scope: 'gh-release', verbose, stdout })
 
   const version = semver.valid(userVersion)
@@ -47,10 +52,10 @@ export async function handler ({ semver: userVersion, path, gitUrl, verbose, std
 
   getMarkdownRelease(file, { version })
 
-  await createGithubRelease({ file, version, success, info, warn, error, gitParsed })
+  await createGithubRelease({ file, version, success, info, warn, error, gitParsed, releasePrefix })
 }
 
-export async function createGithubRelease ({ file, version, success, info, warn, error, gitParsed }) {
+export async function createGithubRelease ({ file, version, success, info, warn, error, gitParsed, releasePrefix }) {
   if (!gitParsed) {
     warn('We cannot find the repository info for your github release.')
     return
@@ -67,8 +72,8 @@ export async function createGithubRelease ({ file, version, success, info, warn,
     const data = {
       user: gitParsed.owner,
       repo: gitParsed.name,
-      tag: `v${version}`,
-      title: `v${version}`,
+      tag: `${releasePrefix}${version}`,
+      title: `${releasePrefix}${version}`,
       body: getMarkdownRelease(file, { version }),
       isPrerelease: Boolean(semver.prerelease(version))
     }

--- a/packages/chan/src/commands/release.js
+++ b/packages/chan/src/commands/release.js
@@ -54,6 +54,11 @@ export const builder = {
     type: 'boolean',
     default: false
   },
+  'release-prefix': {
+    describe: 'Define the release prefix to be used',
+    type: 'string',
+    default: 'v'
+  },
   ghrelease: {
     describe: 'Uploads a github release based on your CHANGELOG',
     type: 'boolean',
@@ -76,6 +81,7 @@ export async function handler ({
   allowYanked,
   allowPrerelease,
   mergePrerelease,
+  releasePrefix,
   ghrelease,
   git,
   verbose,
@@ -122,7 +128,8 @@ export async function handler ({
       gitBranch,
       allowYanked,
       allowPrerelease,
-      mergePrerelease
+      mergePrerelease,
+      releasePrefix
     })
 
     await write({ file, stdout })
@@ -131,7 +138,7 @@ export async function handler ({
       if (!gitParsed) {
         file.message('Cannot create a Github Release without the git url. Use `--git-url` param.')
       }
-      await createGithubRelease({ file, version, success, info, warn, error, gitParsed })
+      await createGithubRelease({ file, version, success, info, warn, error, gitParsed, releasePrefix })
     }
 
     report(file)

--- a/packages/chan/tests/release.test.js
+++ b/packages/chan/tests/release.test.js
@@ -17,6 +17,7 @@ test('export yarg command structure', () => {
   expect(release.builder).toHaveProperty('merge-prerelease')
   expect(release.builder).toHaveProperty('ghrelease')
   expect(release.builder).toHaveProperty('git')
+  expect(release.builder).toHaveProperty('release-prefix')
 
   expect(release.handler).toBeDefined()
 })


### PR DESCRIPTION
### 💬 Describe the pull request
For now, the `chan-cli` and `chan-core` packages use an hardcoded release/tag prefix `v`. Used for tagging release & gh-release.
Some company or person may need to handle the version tagging with another or no prefix.

This PR intend to allow anybody to choose another prefix by using a new configuration named  `--release-prefix`.

### 🔢 To Review
Steps to review the PR:

### `chan release`
1. use the new `--release-prefix`
2. the resulting `CHANGELOG.md` file must use the chosen prefix

### `chan gh-release`
1. use the new `--release-prefix`
2. the github redirection should use the chosen prefix

### `chanrc`, `chanrc.json`, `package.json`
1. add the new config key `release-prefix` into one of `chanrc`, `chanrc.json`, `package.json` 
2. when using both `chan release` or `chan gh-release` the release must be prefixed with the configured value
