### PR TITLE
fix: reference correct octokit action for creating release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- reference correct octokit action for creating releases #67
 
 ## [3.2.1] - 2021-09-22
 ### Fixed

--- a/packages/chan/src/commands/gh-release.js
+++ b/packages/chan/src/commands/gh-release.js
@@ -81,7 +81,7 @@ export async function createGithubRelease ({ file, version, success, info, warn,
     if (process.env.GITHUB_TOKEN) {
       const github = getOctokit(process.env.GITHUB_TOKEN)
 
-      await github.repos.createRelease({
+      await github.rest.repos.createRelease({
         owner: data.user,
         repo: data.repo,
         tag_name: data.tag,


### PR DESCRIPTION
Hello! This is for a fix for creating GitHub releases (#67 )

What I've done:
1. Updated octokit command for `createRelease`
2. Verified no existing tests have regressed

```sh
lerna success run Ran npm script 'lint' in 6 packages in 6.8s:
lerna success - @geut/chan-core
lerna success - @geut/chan-stringify
lerna success - @geut/chan
lerna success - @geut/chast
lerna success - @geut/git-url-parse
lerna success - @geut/remark-chan
```

3. Verified new code creates release successfully

```sh
 λ npm link
 λ chan added "New chan release"
[chan] [added] › ✔  success   Added new changes on your changelog.
 λ chan release 0.1.4
[chan] [release] › ✔  success   New release created. 0.1.4
 λ export GITHUB_TOKEN=<REDACTED>
 λ chan gh-release 0.1.4
[chan] [gh-release] › ℹ  info      Uploading GitHub release...
[chan] [gh-release] › ✔  success   GitHub release created.
```

What I did not do:
1. Write new tests to validate this behavior 😞  - I really have no idea how I would do that here in js